### PR TITLE
Added Antlers parsing within the consent_manager:require tag

### DIFF
--- a/src/Tags/Concerns/HandlesRequireTag.php
+++ b/src/Tags/Concerns/HandlesRequireTag.php
@@ -3,6 +3,7 @@
 namespace Eminos\StatamicConsentManager\Tags\Concerns;
 
 use Illuminate\Support\Str;
+use Statamic\Facades\Antlers;
 
 /**
  * Trait for handling the consent_manager:require tag functionality
@@ -44,7 +45,7 @@ trait HandlesRequireTag
             $content = preg_replace('/\{\{\s*placeholder\s*\}\}.*?\{\{\s*\/placeholder\s*\}\}/s', '', $rawContent);
         }
         
-        $content = trim($content);
+        $content = (string) Antlers::parse(trim($content), $this->context);
 
         if (!$service) {
             return '<!-- consent_manager:require - service parameter required -->';


### PR DESCRIPTION
Hey there,

I’ve checked out your addon and it fits our requirements really well. While using it, I noticed that Antlers variables couldn’t be output directly within the tag. I added this functionality by adding the Antlers parser to the content variable. It would be great if it could be included in a future release.

Thanks for your work on this addon!